### PR TITLE
Allows for a way to run generic validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /doc/
 /libs/
+/lib/
 /.crystal/
 /.shards/
 db/

--- a/spec/changeset_spec.cr
+++ b/spec/changeset_spec.cr
@@ -84,5 +84,29 @@ describe Crecto do
         changeset.errors[0].should eq({:field => "name", :message => "is invalid"})
       end
     end
+
+    describe "#validate" do
+      it "should not be valid" do
+        u = UserGenericValidation.new
+        changeset = UserGenericValidation.changeset(u)
+        changeset.valid?.should be_false
+      end
+
+      it "should have some errors" do
+        u = UserGenericValidation.new
+        changeset = UserGenericValidation.changeset(u)
+        changeset.errors.size.should be > 0
+        changeset.errors[0].should eq({:field => "_base", :message => "Password must exist"})
+      end
+
+      it "should not have some errors and be valid" do
+        u = UserGenericValidation.new
+        u.id = 123
+        u.password = "awesome"
+        changeset = UserGenericValidation.changeset(u)
+        changeset.errors.size.should eq(0)
+        changeset.valid?.should be_true
+      end
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -98,6 +98,26 @@ class UserLength
   validate_length :name, max: 5
 end
 
+class UserGenericValidation
+  include Crecto::Schema
+  extend Crecto::Changeset(UserGenericValidation)
+
+  schema "user_generic" do
+    field :id, Int32, primary_key: true
+    field :password, String, virtual: true
+    field :encrypted_password, String
+  end
+
+  validate "Password must exist", ->(user : UserGenericValidation) do
+    if !(user.id.nil? || user.id == "")
+      if !(user.password.nil? || user.password == "")
+        return true
+      end
+    end
+    return false
+  end
+end
+
 class Thing
   include Crecto::Schema
 
@@ -119,5 +139,5 @@ class Tester
 
 	schema "testers" do
 		field :oof, String
-	end	
+	end
 end

--- a/src/crecto/changeset.cr
+++ b/src/crecto/changeset.cr
@@ -18,6 +18,21 @@ module Crecto
     REQUIRED_RANGE_EXCLUSIONS = {} of String => Array(NamedTuple(field: Symbol, in: Range(Int32, Int32) | Range(Float64, Float64) | Range(Time, Time) | Range(Time, Time)))
     # :nodoc:
     REQUIRED_LENGTHS = {} of String => Array(NamedTuple(field: Symbol, is: Int32 | Nil, min: Int32 | Nil, max: Int32 | Nil))
+    # :nodoc:
+    macro extended
+      # :nodoc:
+      REQUIRED_GENERIC = [] of NamedTuple(message: String, validation: Proc({{ @type.id }}, Bool))
+
+      # Validates generic proc against an instance of the class
+      def self.validate(message : String, block : Proc({{ @type.id }}, Bool | Nil))
+        REQUIRED_GENERIC.push({message: message, validation: block})
+      end
+
+      # :nodoc:
+      def self.required_generics
+        REQUIRED_GENERIC
+      end
+    end
 
     def changeset(instance)
       Changeset(T).new(instance)

--- a/src/crecto/changeset/changeset.cr
+++ b/src/crecto/changeset/changeset.cr
@@ -41,6 +41,7 @@ module Crecto
         check_array_exclusions!
         check_range_exclusions!
         check_lengths!
+        check_generic_validations!
         diff_from_initial_values!
       end
 
@@ -89,7 +90,7 @@ module Crecto
           elsif inclusion[:in].is_a?(Range(Int32, Int32)) && val.is_a?(Int32)
             add_error(inclusion[:field].to_s, "is invalid") unless inclusion[:in].as(Range(Int32, Int32)).includes?(val.as(Int32))
           elsif inclusion[:in].is_a?(Range(Time, Time)) && val.is_a?(Time)
-            add_error(inclusion[:field].to_s, "is invalid") unless inclusion[:in].as(Range(Time, Time)).includes?(val.as(Time))            
+            add_error(inclusion[:field].to_s, "is invalid") unless inclusion[:in].as(Range(Time, Time)).includes?(val.as(Time))
           end
         end
       end
@@ -113,7 +114,7 @@ module Crecto
           elsif exclusion[:in].is_a?(Range(Int32, Int32)) && val.is_a?(Int32)
             add_error(exclusion[:field].to_s, "is invalid") if exclusion[:in].as(Range(Int32, Int32)).includes?(val.as(Int32))
           elsif exclusion[:in].is_a?(Range(Time, Time)) && val.is_a?(Time)
-            add_error(exclusion[:field].to_s, "is invalid") if exclusion[:in].as(Range(Time, Time)).includes?(val.as(Time))            
+            add_error(exclusion[:field].to_s, "is invalid") if exclusion[:in].as(Range(Time, Time)).includes?(val.as(Time))
           end
         end
       end
@@ -134,6 +135,14 @@ module Crecto
         @changes.clear
         @instance_hash.each do |field, value|
           @changes.push({field => value}) if @initial_values.as(Hash).fetch(field, nil) != value
+        end
+      end
+
+      private def check_generic_validations!
+        @instance.class.required_generics.each do |tuple|
+          if !tuple[:validation].call(@instance)
+            add_error("_base", tuple[:message])
+          end
         end
       end
 


### PR DESCRIPTION
Runs on an instance of the class. The proc literal requires that a Bool be returned at all times. This way you know if it passed for failed. The message ends up in a generic "_base" error message field. Theres a potential to create better error objects so that "_base" can be managed better.

Wanted to get this out there first before I go too far. 