### PR TITLE
Parameterized queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ puts changeset.instance.name # "new name"
 #
 query = Crecto::Repo::Query
   .where(name: "new name")
-  .where("users.age < 124")
+  .where("users.age < ?", [124])
   .order_by("users.name ASC")
   .order_by("users.age DESC")
   .limit(1)

--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -43,7 +43,7 @@ describe Crecto do
       it "should return rows" do
         query = Crecto::Repo::Query
           .where(name: "fridge")
-          .where("users.things < 124")
+          .where("users.things < ?", [124])
           .order_by("users.name ASC")
           .order_by("users.things DESC")
           .limit(1)

--- a/src/crecto/adapters/postgres_adapter.cr
+++ b/src/crecto/adapters/postgres_adapter.cr
@@ -96,7 +96,7 @@ module Crecto
         q.push  "#{changeset.instance.class.table_name}"
         q.push  "(#{fields_values[:fields]})"
         q.push  "VALUES"
-        q.push  "(#{fields_values[:values].map{|v| "?" }.join(", ")})"
+        q.push  "(#{(1..fields_values[:values].size).map{ "?" }.join(", ")})"
         q.push  "RETURNING *"
 
         connection.exec(position_args(q.join(" ")), fields_values[:values])
@@ -110,7 +110,7 @@ module Crecto
         q.push  "SET"
         q.push  "(#{fields_values[:fields]})"
         q.push  "="
-        q.push  "(#{fields_values[:values].map{|v| "?" }.join(", ")})"
+        q.push  "(#{(1..fields_values[:values].size).map{ "?" }.join(", ")})"
         q.push  "WHERE"
         q.push  "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
         q.push  "RETURNING *"

--- a/src/crecto/query.cr
+++ b/src/crecto/query.cr
@@ -6,7 +6,7 @@ module Crecto
     #
     class Query
       property selects : Array(String)
-      property wheres = [] of Hash(Symbol, Int32) | Hash(Symbol, String) | Hash(Symbol, Array(Int32)) | Hash(Symbol, Array(String)) | Hash(Symbol, Int32 | String) | String
+      property wheres = [] of Hash(Symbol, Int32) | Hash(Symbol, String) | Hash(Symbol, Array(Int32)) | Hash(Symbol, Array(String)) | Hash(Symbol, Int32 | String) | NamedTuple(clause: String, params: Array(DbValue))
       property joins = [] of Hash(Symbol, Hash(Symbol, String | Array(String)))
       property order_bys = [] of String
       property limit : Int32?
@@ -23,8 +23,8 @@ module Crecto
       end
 
       # Query where with a string (i.e. `.where("users.id > 10"))
-      def self.where(where_string : String)
-        self.new.where(where_string)
+      def self.where(where_string : String, params : Array(DbValue))
+        self.new.where(where_string, params)
       end
 
       # TODO: not done yet
@@ -64,8 +64,8 @@ module Crecto
         self
       end
 
-      def where(where_string : String)
-        @wheres.push where_string
+      def where(where_string : String, params : Array(DbValue))
+        @wheres.push({clause: where_string, params: params.map{|p| p.as(DbValue)}})
         self
       end
 

--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -131,15 +131,18 @@ module Crecto
         query_hash = {} of Symbol => DbValue
 
         {% for field in FIELDS %}
-          query_hash[{{field}}] = self.{{field.id}} if self.{{field.id}} && @@changeset_fields.includes?({{field}})
+          if self.{{field.id}} && @@changeset_fields.includes?({{field}})
+            query_hash[{{field}}] = self.{{field.id}}
+            query_hash[{{field}}] = query_hash[{{field}}].as(Time).to_utc if query_hash[{{field}}].is_a?(Time)
+          end
         {% end %}
 
         {% unless CREATED_AT_FIELD == nil %}
-          query_hash[{{CREATED_AT_FIELD.id.symbolize}}] = self.{{CREATED_AT_FIELD.id}}
+          query_hash[{{CREATED_AT_FIELD.id.symbolize}}] = self.{{CREATED_AT_FIELD.id}}.nil? ? nil : self.{{CREATED_AT_FIELD.id}}.as(Time).to_utc
         {% end %}
 
         {% unless UPDATED_AT_FIELD == nil %}
-          query_hash[{{UPDATED_AT_FIELD.id.symbolize}}] = self.{{UPDATED_AT_FIELD.id}}
+          query_hash[{{UPDATED_AT_FIELD.id.symbolize}}] = self.{{UPDATED_AT_FIELD.id}}.nil? ? nil : self.{{UPDATED_AT_FIELD.id}}.as(Time).to_utc
         {% end %}
 
         query_hash


### PR DESCRIPTION
closes #2 

Pass query parameters as separate arguments as per [crystal-pg](https://github.com/will/crystal-pg#typed-querying) to prevent against SQL injection