### PR TITLE
index out of bounds error when using #get and #get_by

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -85,6 +85,11 @@ describe Crecto do
         user.id.should eq(1121)
         user.some_date.should eq(Time.now.at_beginning_of_hour)
       end
+
+      it "should not return a user if not in db" do
+        user = Crecto::Repo.get(User, 1)
+        user.nil?.should be_true
+      end
     end
 
     describe "#get_by" do
@@ -92,6 +97,11 @@ describe Crecto do
         user = Crecto::Repo.get_by(User, name: "fridge", id: 1121).as(User)
         user.id.should eq(1121)
         user.name.should eq("fridge")
+      end
+
+      it "should not return a row" do
+        user = Crecto::Repo.get_by(User, id: 1)
+        user.nil?.should be_true
       end
     end
 

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -19,7 +19,7 @@ module Crecto
     # ```
     def self.get(queryable, id)
       query = Crecto::Adapters::Postgres.execute(:get, queryable, id)
-      queryable.from_sql(query.to_hash[0]) unless query.nil?
+      queryable.from_sql(query.to_hash[0]) unless query.nil? || query.rows.size == 0
     end
 
     # Return a single instance of `queryable` using the *query* param
@@ -29,7 +29,7 @@ module Crecto
     # ```
     def self.get_by(queryable, **opts)
       query = Crecto::Adapters::Postgres.execute(:all, queryable, Query.where(**opts).limit(1))
-      queryable.from_sql(query.to_hash[0]) unless query.nil?
+      queryable.from_sql(query.to_hash[0]) unless query.nil? || query.rows.size == 0
     end
 
     # Insert a schema instance into the data store.


### PR DESCRIPTION
weird. in situations where results weren't being returned by #get or #get_by, a `nil?` check wasn't sufficient. Calls to `.to_hash` on the PgResult were resulting in index out of bound errors. Added a check to make sure rows *actually* didn't exist.