### PR TITLE
removed micrate as a dependency and added some make commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database crecto_test;' -U postgres
-  - mkdir -p db/migrations && cp spec/migrations/20161120183426_users.sql db/migrations/
-  - ./spec/migrate up
+  - psql $PG_URL < spec/migrations/pg_users.sql
 env:
   - PG_URL=postgres://postgres@localhost:5432/crecto_test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+## Migrate database and run specs
+##   $ make all
+## Migrate database only
+##   $ make migrate
+## Runs specs only
+##   $ make spec
+
+migrate:
+ifndef PG_URL
+	$(error PG_URL is undefined)
+else
+	psql -q $(PG_URL) < ./spec/migrations/pg_users.sql
+endif
+
+spec:
+	crystal spec
+
+all: migrate spec
+
+.PHONY: migrate spec all

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ puts "elapsed: #{end_time-start_time}"
 4. Push to the branch (git push origin my-new-feature)
 5. Create a new Pull Request
 
+### Development Notes
+
+When developing against crecto, the database must exist in Postgres prior to
+testing. The environment variable `PG_URL` must be set to the database that will
+be used for testing. A couple commands have been set up to ease development:
+
+*  `make migrate` - This will remigrate the testing schema to the database.
+*  `make spec` - Runs the crystal specs for crecto
+*  `make all` - Runs the migration and subsequently runs specs
+
 ## Thanks / Inspiration
 
 * [Ecto](https://github.com/elixir-ecto/ecto)

--- a/shard.yml
+++ b/shard.yml
@@ -13,6 +13,3 @@ dependencies:
 
   pool:
     github: ysbaddaden/pool
-
-  micrate:
-    github: juanedi/micrate

--- a/spec/migrate
+++ b/spec/migrate
@@ -1,4 +1,0 @@
-#! /usr/bin/env crystal
-require "micrate"
-
-Micrate::Cli.run

--- a/spec/migrations/pg_users.sql
+++ b/spec/migrations/pg_users.sql
@@ -1,5 +1,11 @@
--- +micrate Up
 BEGIN;
+
+DROP INDEX IF EXISTS users_4ijlkjdf;
+DROP TABLE IF EXISTS users;
+DROP INDEX IF EXISTS users_different_defaults_kljl3kj;
+DROP TABLE IF EXISTS users_different_defaults;
+DROP INDEX IF EXISTS users_4asdf;
+DROP TABLE IF EXISTS users_large_defaults;
 
 CREATE TABLE users(
   id INTEGER NOT NULL,
@@ -62,11 +68,3 @@ ALTER TABLE ONLY users_large_defaults ALTER COLUMN id SET DEFAULT nextval('users
 CREATE UNIQUE INDEX users_4asdf ON users_large_defaults (id);
 
 COMMIT;
-
--- +micrate Down
-DROP INDEX users_4ijlkjdf;
-DROP TABLE users;
-DROP INDEX users_different_defaults_kljl3kj;
-DROP TABLE users_different_defaults;
-DROP INDEX users_4asdf;
-DROP TABLE users_large_defaults;


### PR DESCRIPTION
```
# migrates database
$ make migrate
psql -q postgres://localhost/crecto_development < ./spec/migrations/pg_users.sql

# runs specs
$ make spec
crystal spec
.......................................................

Finished in 33.82 milliseconds
55 examples, 0 failures, 0 errors, 0 pending

# runs migration and specs right after
$ make all
psql -q postgres://localhost/crecto_development < ./spec/migrations/pg_users.sql
crystal spec
.......................................................

Finished in 33.82 milliseconds
55 examples, 0 failures, 0 errors, 0 pending
```

For the migrations, `PG_URL` needs to be set prior to running the command and the database needs to be created in Postgres.