### PR TITLE
Add Hash(with Int64) types to WhereType

### DIFF
--- a/src/crecto.cr
+++ b/src/crecto.cr
@@ -12,7 +12,7 @@ alias DbValue = Bool | Float32 | Float64 | Int64 | Int32 | String | Time | Nil
 # :nodoc:
 alias PkeyValue = Int32 | Int64 | Nil
 # :nodoc:
-alias WhereType = Hash(Symbol, PkeyValue) | Hash(Symbol, DbValue) | Hash(Symbol, Array(DbValue)) | Hash(Symbol, Array(PkeyValue)) | Hash(Symbol, Array(Int32)) | Hash(Symbol, Array(Int64)) | Hash(Symbol, Array(String)) | Hash(Symbol, Int32 | String) | Hash(Symbol, Int32) | Hash(Symbol, Int64) | Hash(Symbol, String) | Hash(Symbol, Int32 | Int64 | String | Nil) | NamedTuple(clause: String, params: Array(DbValue | PkeyValue))
+alias WhereType = Hash(Symbol, PkeyValue) | Hash(Symbol, DbValue) | Hash(Symbol, Array(DbValue)) | Hash(Symbol, Array(PkeyValue)) | Hash(Symbol, Array(Int32)) | Hash(Symbol, Array(Int64)) | Hash(Symbol, Array(String)) | Hash(Symbol, Int32 | String) | Hash(Symbol, Int64 | String) | Hash(Symbol, Int32) | Hash(Symbol, Int64) | Hash(Symbol, String) | Hash(Symbol, Int32 | Int64 | String) | Hash(Symbol, Int32 | Int64 | String | Nil) | NamedTuple(clause: String, params: Array(DbValue | PkeyValue))
 
 module Crecto
 end


### PR DESCRIPTION
PR will add the below 2 types to `WhereType`
- `Hash(Symbol, Int32 | Int64 | String)`
- `Hash(Symbol, Int64 | String)`
