### PR TITLE
Fix to support unstrict mapping

### DIFF
--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -143,7 +143,7 @@ module Crecto
         {% mapping.push(UPDATED_AT_FIELD.id.stringify + ": {type: Time, nilable: true}") %}
       {% end %}
 
-      DB.mapping({ {{mapping.uniq.join(", ").id}} })
+      DB.mapping({ {{mapping.uniq.join(", ").id}} }, false)
       JSON.mapping({ {{mapping.uniq.join(", ").id}} })
 
       {% for field in json_fields %}


### PR DESCRIPTION
For example: 

In table have: name, slug, title, body
Bug fields only defined: name, title