### PR TITLE
Return if preload ids is empty for fix bad SQL.

### DIFF
--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -433,6 +433,7 @@ module Crecto
 
     private def self.belongs_to_preload(results, queryable, preload)
       ids = results.map { |r| queryable.foreign_key_value_for_association(preload, r) }
+      return if ids.empty?
       query = Crecto::Repo::Query.where(id: ids)
       relation_items = all(queryable.klass_for_association(preload), query)
 


### PR DESCRIPTION
```
Exception: syntax error at or near ")" (PQ::PQError)
0x10c2923c2: *CallStack::unwind:Array(Pointer(Void)) at ??
0x10c292361: *CallStack#initialize:Array(Pointer(Void)) at ??
0x10c292338: *CallStack::new:CallStack at ??
0x10c28acd1: *raise<Exception+>:NoReturn at ??
0x10c419dc2: *DB::Statement+@DB::Statement#perform_query_with_rescue<Array(Array(Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil) | Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil)>:PG::ResultSet at ??
0x10c419d59: *DB::Statement+@DB::Statement#query<Array(Array(Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil) | Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil)>:PG::ResultSet at ??
0x10c443014: *DB::PoolStatement+@DB::PoolStatement#query<Array(Array(Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil) | Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil)>:PG::ResultSet at ??
0x10c3f7589: *DB::Database@DB::QueryMethods#query<String, Array(Array(Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil) | Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil)>:PG::ResultSet at ??
0x10c453712: *Crecto::Adapters::Postgres@Crecto::Adapters::BaseAdapter::execute<String, Array(Array(Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil) | Bool | Float32 | Float64 | Int32 | Int64 | JSON::Any | String | Time | Nil)>:PG::ResultSet at ??
0x10c454055: *Crecto::Adapters::Postgres@Crecto::Adapters::BaseAdapter::all<Crecto::Model+:Class, Crecto::Repo::Query>:PG::ResultSet at ??
0x10c453a55: *Crecto::Adapters::Postgres@Crecto::Adapters::BaseAdapter::run<Symbol, Crecto::Model+:Class, Crecto::Repo::Query>:(PG::ResultSet | Nil) at ??
```

Use case:

```rb
get "/t/:id" do |ctx|
  query = Repo::Query..where("topic_id = 10")
                     .order_by("id asc")
                     .preload(:user)
end
```