### PR TITLE
Fix nil updates

### DIFF
--- a/spec/adapters/mysql_adapter_spec.cr
+++ b/spec/adapters/mysql_adapter_spec.cr
@@ -38,7 +38,7 @@ if Crecto::Repo::ADAPTER == Crecto::Adapters::Mysql
       Crecto::Repo.insert(User.from_json(%({ "name": "chuck" })))
       check_sql do |sql|
         sql.should eq([
-          "INSERT INTO users (name, created_at, updated_at) VALUES (?, ?, ?)",
+          "INSERT INTO users (name, things, nope, yep, some_date, pageviews, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
           "SELECT * FROM users WHERE id = LAST_INSERT_ID()"
         ])
       end
@@ -70,10 +70,11 @@ if Crecto::Repo::ADAPTER == Crecto::Adapters::Mysql
       changeset = Crecto::Repo.insert(User.from_json(%({ "name": "linus" })))
       Crecto::Adapters.clear_sql
       changeset.instance.name = "snoopy"
+      changeset.instance.yep = false
       Crecto::Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq([
-          "UPDATE users SET name=?, created_at=?, updated_at=? WHERE id=#{changeset.instance.id}",
+          "UPDATE users SET name=?, things=?, nope=?, yep=?, some_date=?, pageviews=?, created_at=?, updated_at=? WHERE id=#{changeset.instance.id}",
           "SELECT * FROM users WHERE id = #{changeset.instance.id}"
         ])
       end

--- a/spec/adapters/postgres_adapter_spec.cr
+++ b/spec/adapters/postgres_adapter_spec.cr
@@ -39,7 +39,8 @@ describe "Crecto::Adapters::Postgres" do
   it "should generate insert query" do
     Crecto::Repo.insert(User.from_json(%({ "name": "chuck" })))
     check_sql do |sql|
-      sql.should eq(["INSERT INTO users (name, created_at, updated_at) VALUES ($1, $2, $3) RETURNING *"])
+      sql.should eq(["INSERT INTO users (name, things, nope, yep, some_date, pageviews, created_at, updated_at) \
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *"])
     end
   end
 
@@ -71,7 +72,8 @@ describe "Crecto::Adapters::Postgres" do
     changeset.instance.name = "snoopy"
     Crecto::Repo.update(changeset.instance)
     check_sql do |sql|
-      sql.should eq(["UPDATE users SET (name, created_at, updated_at) = ($1, $2, $3) WHERE id=#{changeset.instance.id} RETURNING *"])
+      sql.should eq(["UPDATE users SET (name, things, nope, yep, some_date, pageviews, created_at, updated_at) = \
+        ($1, $2, $3, $4, $5, $6, $7, $8) WHERE id=#{changeset.instance.id} RETURNING *"])
     end
   end
 

--- a/spec/adapters/sqlite3_adapter_spec.cr
+++ b/spec/adapters/sqlite3_adapter_spec.cr
@@ -35,10 +35,10 @@ if Crecto::Repo::ADAPTER == Crecto::Adapters::SQLite3
     end
 
     it "should generate insert query" do
-      u = Crecto::Repo.insert(User.from_json(%({ "name": "chuck" })))
+      u = Crecto::Repo.insert(User.from_json(%({ "name": "chuck", "yep": false })))
       check_sql do |sql|
         sql.should eq([
-          "INSERT INTO users (name, created_at, updated_at) VALUES (?, ?, ?)",
+          "INSERT INTO users (name, things, nope, yep, some_date, pageviews, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
           "SELECT * FROM users WHERE id = #{u.instance.id}"
         ])
       end
@@ -67,13 +67,14 @@ if Crecto::Repo::ADAPTER == Crecto::Adapters::SQLite3
     end
 
     it "should generate update queries" do
-      changeset = Crecto::Repo.insert(User.from_json(%({ "name": "linus" })))
+      changeset = Crecto::Repo.insert(User.from_json(%({ "name": "linus", "yep": true })))
       Crecto::Adapters.clear_sql
       changeset.instance.name = "snoopy"
+      changeset.instance.yep = false
       Crecto::Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq([
-          "UPDATE users SET name=?, created_at=?, updated_at=? WHERE id=#{changeset.instance.id}",
+          "UPDATE users SET name=?, things=?, nope=?, yep=?, some_date=?, pageviews=?, created_at=?, updated_at=? WHERE id=#{changeset.instance.id}",
           "SELECT * FROM users WHERE id = #{changeset.instance.id}"
         ])
       end

--- a/spec/migrations/mysql_migrations.sql
+++ b/spec/migrations/mysql_migrations.sql
@@ -18,7 +18,7 @@ CREATE TABLE users(
   yep bool,
   pageviews bigint,
   some_date DATETIME,
-  created_at DATETIME,  
+  created_at DATETIME,
   updated_at DATETIME
 );
 
@@ -64,6 +64,7 @@ CREATE UNIQUE INDEX addresses_dfd7fs7ss ON addresses (id);
 CREATE TABLE projects(
   id INTEGER NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (id),
+  name VARCHAR(255),
   created_at DATETIME,
   updated_at DATETIME
 );

--- a/spec/migrations/pg_users.sql
+++ b/spec/migrations/pg_users.sql
@@ -118,6 +118,7 @@ CREATE UNIQUE INDEX addresses_dfd7fs7ss ON addresses (id);
 
 CREATE TABLE projects(
   id INTEGER NOT NULL,
+  name VARCHAR(255),
   created_at timestamp without time zone,
   updated_at timestamp without time zone
 );

--- a/spec/migrations/sqlite3_migrations.sql
+++ b/spec/migrations/sqlite3_migrations.sql
@@ -58,6 +58,7 @@ CREATE UNIQUE INDEX addresses_dfd7fs7ss ON addresses (id);
 
 CREATE TABLE projects(
   id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255),
   created_at DATETIME,
   updated_at DATETIME
 );

--- a/spec/schema_spec.cr
+++ b/spec/schema_spec.cr
@@ -38,7 +38,7 @@ describe Crecto do
 
           now = Time.now
           u.xyz = now
-          u.to_query_hash.should eq({:xyz => now})
+          u.to_query_hash.should eq({:name => nil, :xyz => now})
           UserDifferentDefaults.primary_key_field.should eq("user_id")
         end
 
@@ -57,7 +57,7 @@ describe Crecto do
         u.nope = 34.9900
         u.pageviews = 1234567890
 
-        u.to_query_hash.should eq({:name => "tester", :things => 6644, :nope => 34.9900, :created_at => nil, :updated_at => nil, :pageviews => 1234567890})
+        u.to_query_hash.should eq({:name => "tester", :things => 6644, :nope => 34.99, :yep => nil, :some_date => nil, :pageviews => 1234567890, :created_at => nil, :updated_at => nil})
       end
     end
 

--- a/src/crecto/changeset/changeset.cr
+++ b/src/crecto/changeset/changeset.cr
@@ -56,14 +56,14 @@ module Crecto
       private def check_required!
         return unless REQUIRED_FIELDS.has_key?(@class_key)
         REQUIRED_FIELDS[@class_key].each do |field|
-          add_error(field.to_s, "is required") unless @instance_hash.has_key?(field)
+          add_error(field.to_s, "is required") unless @instance_hash[field]?
         end
       end
 
       private def check_formats!
         return unless REQUIRED_FORMATS.has_key?(@class_key)
         REQUIRED_FORMATS[@class_key].each do |format|
-          next unless @instance_hash.has_key?(format[:field])
+          next unless @instance_hash[format[:field]]?
           raise Crecto::InvalidType.new("Format validator can only validate strings") unless @instance_hash.fetch(format[:field]).is_a?(String)
           val = @instance_hash.fetch(format[:field]).as(String)
           add_error(format[:field].to_s, "is invalid") if format[:pattern].match(val).nil?
@@ -73,7 +73,7 @@ module Crecto
       private def check_array_inclusions!
         return unless REQUIRED_ARRAY_INCLUSIONS.has_key?(@class_key)
         REQUIRED_ARRAY_INCLUSIONS[@class_key].each do |inclusion|
-          next unless @instance_hash.has_key?(inclusion[:field])
+          next unless @instance_hash[inclusion[:field]]?
           val = @instance_hash.fetch(inclusion[:field])
           add_error(inclusion[:field].to_s, "is invalid") unless inclusion[:in].includes?(val)
         end
@@ -82,7 +82,7 @@ module Crecto
       private def check_range_inclusions!
         return unless REQUIRED_RANGE_INCLUSIONS.has_key?(@class_key)
         REQUIRED_RANGE_INCLUSIONS[@class_key].each do |inclusion|
-          next unless @instance_hash.has_key?(inclusion[:field])
+          next unless @instance_hash[inclusion[:field]]?
           val = @instance_hash.fetch(inclusion[:field])
           if inclusion[:in].is_a?(Range(Float64, Float64)) && val.is_a?(Float64)
             add_error(inclusion[:field].to_s, "is invalid") unless inclusion[:in].as(Range(Float64, Float64)).includes?(val.as(Float64))
@@ -99,7 +99,7 @@ module Crecto
       private def check_array_exclusions!
         return unless REQUIRED_ARRAY_EXCLUSIONS.has_key?(@class_key)
         REQUIRED_ARRAY_EXCLUSIONS[@class_key].each do |exclusion|
-          next unless @instance_hash.has_key?(exclusion[:field])
+          next unless @instance_hash[exclusion[:field]]?
           val = @instance_hash.fetch(exclusion[:field])
           add_error(exclusion[:field].to_s, "is invalid") if exclusion[:in].includes?(val)
         end
@@ -108,7 +108,7 @@ module Crecto
       private def check_range_exclusions!
         return unless REQUIRED_RANGE_EXCLUSIONS.has_key?(@class_key)
         REQUIRED_RANGE_EXCLUSIONS[@class_key].each do |exclusion|
-          next unless @instance_hash.has_key?(exclusion[:field])
+          next unless @instance_hash[exclusion[:field]]?
           val = @instance_hash.fetch(exclusion[:field])
           if exclusion[:in].is_a?(Range(Float64, Float64)) && val.is_a?(Float64)
             add_error(exclusion[:field].to_s, "is invalid") if exclusion[:in].as(Range(Float64, Float64)).includes?(val.as(Float64))
@@ -125,7 +125,7 @@ module Crecto
       private def check_lengths!
         return unless REQUIRED_LENGTHS.has_key?(@class_key)
         REQUIRED_LENGTHS[@class_key].each do |length|
-          next unless @instance_hash.has_key?(length[:field])
+          next unless @instance_hash[length[:field]]?
           val = @instance_hash.fetch(length[:field]).as(String)
           add_error(length[:field].to_s, "is invalid") if !length[:is].nil? && val.size != length[:is].as(Int32)
           add_error(length[:field].to_s, "is invalid") if !length[:min].nil? && val.size < length[:min].as(Int32)

--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -149,7 +149,7 @@ module Crecto
         query_hash = {} of Symbol => DbValue
 
         {% for field in FIELDS %}
-          if self.{{field[:name].id}} && @@changeset_fields.includes?({{field[:name]}})
+          if @@changeset_fields.includes?({{field[:name]}})
             query_hash[{{field[:name]}}] = self.{{field[:name].id}}
             query_hash[{{field[:name]}}] = query_hash[{{field[:name]}}].as(Time).to_utc if query_hash[{{field[:name]}}].is_a?(Time)
           end


### PR DESCRIPTION
Currently crecto doesn't update `nil` and `false`, because `Crecto::Schema#to_query_hash` doesn't return `nil` and `false` fields. This is a fix for that. All specs updated.