### PR TITLE
Fix association typos in Query class

### DIFF
--- a/src/crecto/query.cr
+++ b/src/crecto/query.cr
@@ -115,7 +115,7 @@ module Crecto
         self.new.join(join_association)
       end
 
-      # Preload assoications
+      # Preload associations
       #
       # ```
       # Query.preload([:posts, :projects])
@@ -124,7 +124,7 @@ module Crecto
         self.new.preload(preload_associations)
       end
 
-      # Preload assoication
+      # Preload associations
       #
       # ```
       # Query.preload(:posts)


### PR DESCRIPTION
I was browsing the code and found this small typo. Thanks for writing this! I'm also working on an ORM and it's been helpful to see how you did some things!