### PR TITLE
Remove Zhomark fork from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ require "crecto"
 
 #### Sqlite
 
-~~Include [crystal-sqlite3](https://github.com/crystal-lang/crystal-sqlite3) in your project~~
-Include [zhomarts fork of of crystal-sqlite3](https://github.com/Zhomart/crystal-sqlite3) in your project
+Include [crystal-sqlite3](https://github.com/crystal-lang/crystal-sqlite3) in your project
 
 in your appplication:
 


### PR DESCRIPTION
Looks like this is no longer required as upstream was updated.

https://github.com/fridgerator/crecto/issues/63