### PR TITLE
Fixes #78. Force `param` to be a `DbValue` in `Query.where`.

### DIFF
--- a/src/crecto/repo/query.cr
+++ b/src/crecto/repo/query.cr
@@ -221,7 +221,7 @@ module Crecto
       # Query.where(:name, "Conan")
       # ```
       def where(where_sym : Symbol, param : DbValue)
-        @wheres.push(Hash.zip([where_sym], [param]))
+        @wheres.push({ where_sym => param.as(DbValue) })
         self
       end
 


### PR DESCRIPTION
See #78 for a detailed look at this issue. In short: `param` was being typed as `String | Nil` instead of the more general `DbValue`, which caused the result of `Hash.zip` to not match the type expected by `@wheres.push`. Explicitly casting `param` up to the `DbValue` type solved this issue.

`Hash.zip` also seemed unnecessary, as there is only a single key-value pair, and it can be written using the Hash literal syntax.